### PR TITLE
lib: no global variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,32 @@
-var S3FS = require('s3fs');
-var crypto = require('crypto');
-var path = require('path');
-var options = {};
-var s3fs;
+var S3FS = require('s3fs')
+var crypto = require('crypto')
+
 function S3Storage (opts) {
-  if (!opts.bucket) throw new Error('bucket is required');
-  if (!opts.secretAccessKey) throw new Error('secretAccessKey is required');
-  if (!opts.accessKeyId) throw new Error('accessKeyId is required');
-  if (!opts.region) throw new Error('region is required');
-  if (!opts.dirname) throw new Error('dirname is required');
-  options = opts;
-  s3fs = new S3FS(options.bucket, options);
+  if (!opts.bucket) throw new Error('bucket is required')
+  if (!opts.secretAccessKey) throw new Error('secretAccessKey is required')
+  if (!opts.accessKeyId) throw new Error('accessKeyId is required')
+  if (!opts.region) throw new Error('region is required')
+  if (!opts.dirname) throw new Error('dirname is required')
+
+  this.options = opts
+  this.s3fs = new S3FS(opts.bucket, opts)
 }
 
 S3Storage.prototype._handleFile = function (req, file, cb) {
-  var fileName = crypto.randomBytes(20).toString('hex');
-  var outStream = s3fs.createWriteStream(options.dirname + '/' + fileName);
-  file.stream.pipe(outStream);
-  outStream.on('error', cb);
-  outStream.on('finish', function(){
-    cb(null, {size: outStream.bytesWritten, key: options.dirname + '/' + fileName})
-  });
+  var fileName = crypto.randomBytes(20).toString('hex')
+  var filePath = this.options.dirname + '/' + fileName
+  var outStream = this.s3fs.createWriteStream(filePath)
+
+  file.stream.pipe(outStream)
+
+  outStream.on('error', cb)
+  outStream.on('finish', function () {
+    cb(null, { size: outStream.bytesWritten, key: filePath })
+  })
 }
 
 S3Storage.prototype._removeFile = function (req, file, cb) {
-  s3fs.unlink(file.path, cb)
+  this.s3fs.unlink(file.key, cb)
 }
 
 module.exports = function (opts) {


### PR DESCRIPTION
This changes the library to not depend on global variables. Before this patch you couldn't instantiate two classes without the first one overriding properties in the second one.

It also fixes a bug where `_removeFile` wouldn't use the correct path.

It also makes all code adhere to [JavaScript Standard Style](https://github.com/feross/standard).