### PR TITLE
Added additional file naming options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ npm test
 ```
 
 # Usage
+
+The options ```dirname```, ```bucket```, ```secretAccessKey```, ```accessKeyId```, and ```region``` are required.
+
+If you mark the option ```originalname``` as true then multer will upload the file with the same name and extension as the original uploaded file.
+
+If you provide a string for the ```filename``` option this will override the originalname option. Whatever string you provide will be used by multer for the upload. This file will be overwritten every time a new file is uploaded.
+
+If ```originalname``` and ```filename``` are not provided then the defaul crypto filename will be used.
+
 ```
 var express = require('express');
 var app = express();
@@ -28,7 +37,9 @@ var upload = multer({
     bucket: 'some-bucket',
     secretAccessKey: 'some secret',
     accessKeyId: 'some key',
-    region: 'us-east-1'
+    region: 'us-east-1',
+    originalname:, true // uses the uploaded filename and extensions. Expects a boolean.
+    filename: 'temp', // specify a custom filename for the upload. This will be overwritten everytime you upload something else. Expects a string.
   })
 })
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,20 @@ function S3Storage (opts) {
 }
 
 S3Storage.prototype._handleFile = function (req, file, cb) {
-  var fileName = crypto.randomBytes(20).toString('hex')
+  var extension = file.originalname.slice(-4);
+  var originalFilename = file.originalname.slice(0, -4);
+
+  if (this.options.originalname) {
+    var fileName = file.originalname;
+    console.log('using original name: ', fileName);
+  } else if (!this.options.originalname && this.options.filename) {
+    var fileName = this.options.filename + extension;
+    console.log('using user-defined filename: ', fileName);
+  } else {
+    var fileName = crypto.randomBytes(20).toString('hex')
+    console.log('using crypo name: ', fileName);
+  }
+
   var filePath = this.options.dirname + '/' + fileName
   var outStream = this.s3fs.createWriteStream(filePath)
 


### PR DESCRIPTION
Hey, I used this module in a recent project and found I needed to modify it because it didn't provide many options when it came to custom filenames. I added a few additional options that I think some people may find helpful. I also updated the readme as well. 

The three additional options that can be used when calling the multer-s3 module in app.js are ```originalname```, ```filename```, and ```crypto```. I explain each in more detail in the readme, but the basic idea is that if you want to upload the file with the same name as the original file, add ```originalname: true```. If you want to have one filename that is constantly overwritten, like a temporary file, then use filename with a string. Otherwise, the original crypto name you made is the default. 