### PR TITLE
custom content-type support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,29 @@
-var S3FS = require('s3fs')
+var aws = require('aws-sdk')
+var extend = require('xtend')
 var crypto = require('crypto')
+var stream = require('stream')
+var fileType = require('file-type')
 
 function getFilename (req, file, cb) {
   crypto.pseudoRandomBytes(16, function (err, raw) {
     cb(err, err ? undefined : raw.toString('hex'))
+  })
+}
+
+function defaultContentType (req, file, cb) {
+  setImmediate(function () { cb(null, 'application/octet-stream') })
+}
+
+function autoContentType (req, file, cb) {
+  file.stream.once('data', function (firstChunk) {
+    var type = fileType(firstChunk)
+    var mime = (type === null ? 'application/octet-stream' : type.mime)
+    var outStream = new stream.PassThrough()
+
+    outStream.write(firstChunk)
+    file.stream.pipe(outStream)
+
+    cb(null, mime, outStream)
   })
 }
 
@@ -14,30 +34,51 @@ function S3Storage (opts) {
   if (!opts.region) throw new Error('region is required')
   if (!opts.dirname) throw new Error('dirname is required')
 
+  var s3cfg = extend(opts, { apiVersion: '2006-03-01' })
+
+  delete s3cfg.bucket
+  delete s3cfg.dirname
+
   this.options = opts
   this.getFilename = (opts.filename || getFilename)
-  this.s3fs = new S3FS(opts.bucket, opts)
+  this.getContentType = (opts.contentType || defaultContentType)
+  this.s3 = new aws.S3(s3cfg)
 }
 
 S3Storage.prototype._handleFile = function (req, file, cb) {
   var that = this
   that.getFilename(req, file, function (err, filename) {
-    var filePath = that.options.dirname + '/' + filename
-    var outStream = that.s3fs.createWriteStream(filePath)
+    that.getContentType(req, file, function (err, contentType, _stream) {
+      var currentSize = 0
+      var filePath = that.options.dirname + '/' + filename
 
-    file.stream.pipe(outStream)
+      var upload = that.s3.upload({
+        Bucket: that.options.bucket,
+        Key: filePath,
+        ContentType: contentType,
+        Body: (_stream || file.stream)
+      })
 
-    outStream.on('error', cb)
-    outStream.on('finish', function () {
-      cb(null, { size: outStream.bytesWritten, key: filePath })
+      upload.on('httpUploadProgress', function (ev) {
+        if (ev.total) currentSize = ev.total
+      })
+
+      upload.send(function (err) {
+        if (err) return cb(err)
+
+        cb(null, { size: currentSize, key: filePath })
+      })
     })
   })
 }
 
 S3Storage.prototype._removeFile = function (req, file, cb) {
-  this.s3fs.unlink(file.key, cb)
+  this.s3.deleteObject({ Bucket: this.options.bucket, Key: file.key }, cb)
 }
 
 module.exports = function (opts) {
   return new S3Storage(opts)
 }
+
+module.exports.AUTO_CONTENT_TYPE = autoContentType
+module.exports.DEFAULT_CONTENT_TYPE = defaultContentType

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
   },
   "homepage": "https://github.com/badunk/multer-s3#readme",
   "dependencies": {
-    "s3fs": "^2.0.1"
+    "aws-sdk": "^2.2.16",
+    "file-type": "^3.3.0",
+    "xtend": "^4.0.1"
   },
   "devDependencies": {
-    "aws-sdk": "^2.1.39",
     "chai": "^3.1.0",
     "express": "^4.13.1",
     "mkdirp": "^0.5.1",

--- a/test/integration/express.spec.js
+++ b/test/integration/express.spec.js
@@ -15,9 +15,24 @@ var upload = multer({storage: multers3({
   s3ForcePathStyle: true,
   endpoint: new AWS.Endpoint('http://localhost:4568')
 })});
+var uploadAuto = multer({storage: multers3({
+  dirname: 'uploads/photos',
+  bucket: 'some-bucket',
+  secretAccessKey: 'some secret',
+  accessKeyId: 'some key',
+  region: 'us-east-1',
+  s3ForcePathStyle: true,
+  endpoint: new AWS.Endpoint('http://localhost:4568'),
+  contentType: multers3.AUTO_CONTENT_TYPE
+})});
 
 // express setup
 app.post('/upload', upload.array('photos', 3), function(req, res, next){
+  lastReq = req;
+  lastRes = res;
+  res.status(200).send();
+});
+app.post('/upload-auto', uploadAuto.array('photos', 3), function(req, res, next){
   lastReq = req;
   lastRes = res;
   res.status(200).send();
@@ -36,8 +51,24 @@ describe('express', function(){
       .attach('photos', 'test/fixtures/ffffff.png')
       .end(function(err, res){
         lastReq.files.map(function(file){
-          file.should.have.property('key');
+          file.should.have.property('key')
           file.key.should.have.string('uploads/photos')
+          file.should.have.property('size')
+          file.size.should.equal(68)
+        });
+        done();
+      });
+  });
+  it('returns a req.files with the s3 filename with auto content-type', function(done){
+    supertest(app)
+      .post('/upload-auto')
+      .attach('photos', 'test/fixtures/ffffff.png')
+      .end(function(err, res){
+        lastReq.files.map(function(file){
+          file.should.have.property('key')
+          file.key.should.have.string('uploads/photos')
+          file.should.have.property('size')
+          file.size.should.equal(68)
         });
         done();
       });


### PR DESCRIPTION
The tests could be a bit more extensive and I haven't added documentation yet, but this does all the heavy lifting.

I've replaced `s3fs` with the official `aws-sdk` so this should close #3 as well as #7.

Use it like so:

```javascript
const multerS3 = require('multer-s3')
const storage = new multerS3({
  ...
  contentType: multerS3.AUTO_CONTENT_TYPE
})
```

`contentType` can also be your own function with the signature `(req, file, cb)`.