### PR TITLE
Remove dirname and pass through S3 return data

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,11 @@ var s3 = require('multer-s3');
 
 var upload = multer({
   storage: s3({
-    dirname: 'uploads/photos',
     bucket: 'some-bucket',
     secretAccessKey: 'some secret',
     accessKeyId: 'some key',
     region: 'us-east-1',
-    filename: function (req, file, cb) {
+    key: function (req, file, cb) {
       cb(null, Date.now())
     }
   })

--- a/index.js
+++ b/index.js
@@ -36,7 +36,6 @@ function S3Storage (opts) {
   var s3cfg = extend(opts, { apiVersion: '2006-03-01' })
 
   delete s3cfg.bucket
-  delete s3cfg.dirname
 
   this.options = opts
   this.getKey = (opts.key || getKey)
@@ -64,10 +63,10 @@ S3Storage.prototype._handleFile = function (req, file, cb) {
         if (ev.total) currentSize = ev.total
       })
 
-      upload.send(function (err, data) {
+      upload.send(function (err, result) {
         if (err) return cb(err)
 
-        cb(null, extend(data, { size: currentSize, key: key }))
+        cb(null, { size: currentSize, key: key, location: result.Location, etag: result.ETag })
       })
     })
   })

--- a/index.js
+++ b/index.js
@@ -64,10 +64,10 @@ S3Storage.prototype._handleFile = function (req, file, cb) {
         if (ev.total) currentSize = ev.total
       })
 
-      upload.send(function (err) {
+      upload.send(function (err, data) {
         if (err) return cb(err)
 
-        cb(null, { size: currentSize, key: key })
+        cb(null, extend(data, { size: currentSize, key: key }))
       })
     })
   })

--- a/test/integration/express.spec.js
+++ b/test/integration/express.spec.js
@@ -7,7 +7,6 @@ var should = require('chai').should();
 var AWS = require('aws-sdk')
 var lastReq = lastRes = null;
 var upload = multer({storage: multers3({
-  dirname: 'uploads/photos',
   bucket: 'some-bucket',
   secretAccessKey: 'some secret',
   accessKeyId: 'some key',
@@ -16,7 +15,6 @@ var upload = multer({storage: multers3({
   endpoint: new AWS.Endpoint('http://localhost:4568')
 })});
 var uploadAuto = multer({storage: multers3({
-  dirname: 'uploads/photos',
   bucket: 'some-bucket',
   secretAccessKey: 'some secret',
   accessKeyId: 'some key',
@@ -52,7 +50,6 @@ describe('express', function(){
       .end(function(err, res){
         lastReq.files.map(function(file){
           file.should.have.property('key')
-          file.key.should.have.string('uploads/photos')
           file.should.have.property('size')
           file.size.should.equal(68)
         });
@@ -66,7 +63,6 @@ describe('express', function(){
       .end(function(err, res){
         lastReq.files.map(function(file){
           file.should.have.property('key')
-          file.key.should.have.string('uploads/photos')
           file.should.have.property('size')
           file.size.should.equal(68)
         });


### PR DESCRIPTION
Removes the requirement for `dirname` and changes the `filename` property to `key`. This should resolve issue #9. 

In addition, extend the payload passed back to multer and ultimately to the request file property with the data that is provided by the s3.upload call.