### PR TITLE
key value must be string

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var upload = multer({
     accessKeyId: 'some key',
     region: 'us-east-1',
     key: function (req, file, cb) {
-      cb(null, Date.now())
+      cb(null, Date.now().toString())
     }
   })
 })


### PR DESCRIPTION
aws-sdk returning "InvalidParameterType: Expected params.Key to be a string"
new key 'filename' in uploaded file's data. 