### PR TITLE
Cleanup collect function

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "homepage": "https://github.com/badunk/multer-s3#readme",
   "dependencies": {
-    "file-type": "^3.3.0"
+    "file-type": "^3.3.0",
+    "run-parallel": "^1.1.6"
   },
   "devDependencies": {
     "aws-sdk": "^2.2.32",


### PR DESCRIPTION
We no longer need `setImmediate` since `run-parallel` guards for zalgo 👍 