### PR TITLE
Implementing S3 Server-Side Encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ var upload = multer({
 
 You may use the S3 server-side encryption functionality via the optional `sse` and `sseKms` parameters. Full documentation of these parameters in relation to the S3 API can be found [here] (http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property) and [here] (http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html). 
 
-`sse` has two valid values: 'AES256' and 'aws:kms'. 'AES256' utilizes the S3-managed key system, while 'aws:kms' utilizes the AWS KMS system and accepts the optional `sseKms` parameter to specify the key ID of the key you wish to use. leaving `sseKms` blank when 'aws:kms' is specified will use the default KMS key. **Note:** *You must instantiate the S3 instance with `signatureVersion: 'v4'` in order to use KMS-managed keys.*
+`sse` has two valid values: 'AES256' and 'aws:kms'. 'AES256' utilizes the S3-managed key system, while 'aws:kms' utilizes the AWS KMS system and accepts the optional `sseKms` parameter to specify the key ID of the key you wish to use. Leaving `sseKms` blank when 'aws:kms' is specified will use the default KMS key. **Note:** *You must instantiate the S3 instance with `signatureVersion: 'v4'` in order to use KMS-managed keys [[Docs]] (http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version), and the specified key must be in the same AWS region as the S3 bucket used.*
 
 ```javascript
 var upload = multer({

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ var upload = multer({
 
 You may use the S3 server-side encryption functionality via the optional `sse` and `sseKms` parameters. Full documentation of these parameters in relation to the S3 API can be found [here] (http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property) and [here] (http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html). 
 
-`sse` has two valid values: 'AES256' and 'aws:kms'. 'AES256' utilizes the S3-managed key system, while 'aws:kms' utilizes the AWS KMS system and accepts the optional `sseKms` parameter to specify the key ID of the key you wish to use. leaving `sseKms` blank when 'aws:kms' is specified will use the default KMS key.
+`sse` has two valid values: 'AES256' and 'aws:kms'. 'AES256' utilizes the S3-managed key system, while 'aws:kms' utilizes the AWS KMS system and accepts the optional `sseKms` parameter to specify the key ID of the key you wish to use. leaving `sseKms` blank when 'aws:kms' is specified will use the default KMS key. **Note:** *You must instantiate the S3 instance with `signatureVersion: 'v4'` in order to use KMS-managed keys.*
 
 ```javascript
 var upload = multer({

--- a/README.md
+++ b/README.md
@@ -182,9 +182,9 @@ var upload = multer({
 
 *An overview of S3's server-side encryption can be found in the [S3 Docs] (http://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html); be advised that customer-managed keys (SSE-C) is not implemented at this time.*
 
-You may use the S3 server-side encryption functionality via the optional `sse` and `sseKms` parameters. Full documentation of these parameters in relation to the S3 API can be found [here] (http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property) and [here] (http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html). 
+You may use the S3 server-side encryption functionality via the optional `serverSideEncryption` and `sseKmsKeyId` parameters. Full documentation of these parameters in relation to the S3 API can be found [here] (http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property) and [here] (http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html). 
 
-`sse` has two valid values: 'AES256' and 'aws:kms'. 'AES256' utilizes the S3-managed key system, while 'aws:kms' utilizes the AWS KMS system and accepts the optional `sseKms` parameter to specify the key ID of the key you wish to use. Leaving `sseKms` blank when 'aws:kms' is specified will use the default KMS key. **Note:** *You must instantiate the S3 instance with `signatureVersion: 'v4'` in order to use KMS-managed keys [[Docs]] (http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version), and the specified key must be in the same AWS region as the S3 bucket used.*
+`serverSideEncryption` has two valid values: 'AES256' and 'aws:kms'. 'AES256' utilizes the S3-managed key system, while 'aws:kms' utilizes the AWS KMS system and accepts the optional `sseKmsKeyId` parameter to specify the key ID of the key you wish to use. Leaving `sseKmsKeyId` blank when 'aws:kms' is specified will use the default KMS key. **Note:** *You must instantiate the S3 instance with `signatureVersion: 'v4'` in order to use KMS-managed keys [[Docs]] (http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#specify-signature-version), and the specified key must be in the same AWS region as the S3 bucket used.*
 
 ```javascript
 var upload = multer({
@@ -193,7 +193,7 @@ var upload = multer({
     bucket: 'some-bucket',
     acl: 'authenticated-read',
     contentDisposition: 'attachment',
-    sse: 'AES256',
+    serverSideEncryption: 'AES256',
     key: function(req, file, cb) {
       cb(null, Date.now().toString())
     }

--- a/README.md
+++ b/README.md
@@ -178,6 +178,29 @@ var upload = multer({
 })
 ```
 
+## Using Server-Side Encryption
+
+*An overview of S3's server-side encryption can be found in the [S3 Docs] (http://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html); be advised that customer-managed keys (SSE-C) is not implemented at this time.*
+
+You may use the S3 server-side encryption functionality via the optional `sse` and `sseKms` parameters. Full documentation of these parameters in relation to the S3 API can be found [here] (http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property) and [here] (http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingServerSideEncryption.html). 
+
+`sse` has two valid values: 'AES256' and 'aws:kms'. 'AES256' utilizes the S3-managed key system, while 'aws:kms' utilizes the AWS KMS system and accepts the optional `sseKms` parameter to specify the key ID of the key you wish to use. leaving `sseKms` blank when 'aws:kms' is specified will use the default KMS key.
+
+```javascript
+var upload = multer({
+  storage: multerS3({
+    s3: s3,
+    bucket: 'some-bucket',
+    acl: 'authenticated-read',
+    contentDisposition: 'attachment',
+    sse: 'AES256',
+    key: function(req, file, cb) {
+      cb(null, Date.now().toString())
+    }
+  })
+})
+```
+
 ## Testing
 
 The tests mock all access to S3 and can be run completely offline.

--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ function S3Storage (opts) {
 
   switch (typeof opts.sseKms) {
     case 'function': this.getSSEKMS = opts.sseKms; break
-    case 'string': this.getSSEKMS = opts.sseKms; break
+    case 'string': this.getSSEKMS = staticValue(opts.sseKms); break
     case 'undefined': this.getSSEKMS = defaultSSEKMS; break
     default: throw new TypeError('Expected opts.sseKms to be undefined, string, or function')
   }

--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ var defaultMetadata = staticValue(null)
 var defaultCacheControl = staticValue(null)
 var defaultContentDisposition = staticValue(null)
 var defaultStorageClass = staticValue('STANDARD')
+var defaultSSE = staticValue(null)
+var defaultSSEKMS = staticValue(null)
 
 function defaultKey (req, file, cb) {
   crypto.randomBytes(16, function (err, raw) {
@@ -44,7 +46,9 @@ function collect (storage, req, file, cb) {
     storage.getMetadata.bind(storage, req, file),
     storage.getCacheControl.bind(storage, req, file),
     storage.getContentDisposition.bind(storage, req, file),
-    storage.getStorageClass.bind(storage, req, file)
+    storage.getStorageClass.bind(storage, req, file),
+    storage.getSSE.bind(storage, req, file),
+    storage.getSSEKMS.bind(storage, req, file)
   ], function (err, values) {
     if (err) return cb(err)
 
@@ -60,7 +64,9 @@ function collect (storage, req, file, cb) {
         contentDisposition: values[5],
         storageClass: values[6],
         contentType: contentType,
-        replacementStream: replacementStream
+        replacementStream: replacementStream,
+        sse: values[7],
+        sseKms: values[8]
       })
     })
   })
@@ -124,6 +130,20 @@ function S3Storage (opts) {
     case 'undefined': this.getStorageClass = defaultStorageClass; break
     default: throw new TypeError('Expected opts.storageClass to be undefined, string or function')
   }
+
+  switch (typeof opts.sse) {
+    case 'function': this.getSSE = opts.sse; break
+    case 'string': this.getSSE = staticValue(opts.sse); break
+    case 'undefined': this.getSSE = defaultSSE; break
+    default: throw new TypeError('Expected opts.sse to be undefined, string or function')
+  }
+
+  switch (typeof opts.sseKms) {
+    case 'function': this.getSSEKMS = opts.sseKms; break
+    case 'string': this.getSSEKMS = opts.sseKms; break
+    case 'undefined': this.getSSEKMS = defaultSSEKMS; break
+    default: throw new TypeError('Expected opts.sseKms to be undefined, string, or function')
+  }
 }
 
 S3Storage.prototype._handleFile = function (req, file, cb) {
@@ -140,6 +160,8 @@ S3Storage.prototype._handleFile = function (req, file, cb) {
       ContentType: opts.contentType,
       Metadata: opts.metadata,
       StorageClass: opts.storageClass,
+      ServerSideEncryption: opts.sse,
+      SSEKMSKeyId: opts.sseKms,
       Body: (opts.replacementStream || file.stream)
     }
 
@@ -164,6 +186,7 @@ S3Storage.prototype._handleFile = function (req, file, cb) {
         contentType: opts.contentType,
         contentDisposition: opts.contentDisposition,
         storageClass: opts.storageClass,
+        serverSideEncryption: opts.sse,
         metadata: opts.metadata,
         location: result.Location,
         etag: result.ETag

--- a/index.js
+++ b/index.js
@@ -65,8 +65,8 @@ function collect (storage, req, file, cb) {
         storageClass: values[6],
         contentType: contentType,
         replacementStream: replacementStream,
-        sse: values[7],
-        sseKms: values[8]
+        serverSideEncryption: values[7],
+        sseKmsKeyId: values[8]
       })
     })
   })
@@ -131,18 +131,18 @@ function S3Storage (opts) {
     default: throw new TypeError('Expected opts.storageClass to be undefined, string or function')
   }
 
-  switch (typeof opts.sse) {
-    case 'function': this.getSSE = opts.sse; break
-    case 'string': this.getSSE = staticValue(opts.sse); break
+  switch (typeof opts.serverSideEncryption) {
+    case 'function': this.getSSE = opts.serverSideEncryption; break
+    case 'string': this.getSSE = staticValue(opts.serverSideEncryption); break
     case 'undefined': this.getSSE = defaultSSE; break
-    default: throw new TypeError('Expected opts.sse to be undefined, string or function')
+    default: throw new TypeError('Expected opts.serverSideEncryption to be undefined, string or function')
   }
 
-  switch (typeof opts.sseKms) {
-    case 'function': this.getSSEKMS = opts.sseKms; break
-    case 'string': this.getSSEKMS = staticValue(opts.sseKms); break
+  switch (typeof opts.sseKmsKeyId) {
+    case 'function': this.getSSEKMS = opts.sseKmsKeyId; break
+    case 'string': this.getSSEKMS = staticValue(opts.sseKmsKeyId); break
     case 'undefined': this.getSSEKMS = defaultSSEKMS; break
-    default: throw new TypeError('Expected opts.sseKms to be undefined, string, or function')
+    default: throw new TypeError('Expected opts.sseKmsKeyId to be undefined, string, or function')
   }
 }
 
@@ -160,8 +160,8 @@ S3Storage.prototype._handleFile = function (req, file, cb) {
       ContentType: opts.contentType,
       Metadata: opts.metadata,
       StorageClass: opts.storageClass,
-      ServerSideEncryption: opts.sse,
-      SSEKMSKeyId: opts.sseKms,
+      ServerSideEncryption: opts.serverSideEncryption,
+      SSEKMSKeyId: opts.sseKmsKeyId,
       Body: (opts.replacementStream || file.stream)
     }
 
@@ -186,7 +186,7 @@ S3Storage.prototype._handleFile = function (req, file, cb) {
         contentType: opts.contentType,
         contentDisposition: opts.contentDisposition,
         storageClass: opts.storageClass,
-        serverSideEncryption: opts.sse,
+        serverSideEncryption: opts.serverSideEncryption,
         metadata: opts.metadata,
         location: result.Location,
         etag: result.ETag

--- a/test/basic.js
+++ b/test/basic.js
@@ -91,7 +91,7 @@ describe('Multer S3', function () {
   it('uploads file with AES256 server-side encryption', function (done) {
     var s3 = mockS3()
     var form = new FormData()
-    var storage = multerS3({ s3: s3, bucket: 'test', sse: 'AES256' })
+    var storage = multerS3({ s3: s3, bucket: 'test', serverSideEncryption: 'AES256' })
     var upload = multer({ storage: storage })
     var parser = upload.single('image')
     var image = fs.createReadStream(path.join(__dirname, 'files', 'ffffff.png'))
@@ -119,7 +119,7 @@ describe('Multer S3', function () {
   it('uploads file with AWS KMS-managed server-side encryption', function (done) {
     var s3 = mockS3()
     var form = new FormData()
-    var storage = multerS3({ s3: s3, bucket: 'test', sse: 'aws:kms' })
+    var storage = multerS3({ s3: s3, bucket: 'test', serverSideEncryption: 'aws:kms' })
     var upload = multer({ storage: storage })
     var parser = upload.single('image')
     var image = fs.createReadStream(path.join(__dirname, 'files', 'ffffff.png'))

--- a/test/basic.js
+++ b/test/basic.js
@@ -87,4 +87,60 @@ describe('Multer S3', function () {
       done()
     })
   })
+
+  it('uploads file with AES256 server-side encryption', function (done) {
+    var s3 = mockS3()
+    var form = new FormData()
+    var storage = multerS3({ s3: s3, bucket: 'test', sse: 'AES256' })
+    var upload = multer({ storage: storage })
+    var parser = upload.single('image')
+    var image = fs.createReadStream(path.join(__dirname, 'files', 'ffffff.png'))
+
+    form.append('name', 'Multer')
+    form.append('image', image)
+
+    submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+
+      assert.equal(req.body.name, 'Multer')
+
+      assert.equal(req.file.fieldname, 'image')
+      assert.equal(req.file.originalname, 'ffffff.png')
+      assert.equal(req.file.size, 68)
+      assert.equal(req.file.bucket, 'test')
+      assert.equal(req.file.etag, 'mock-etag')
+      assert.equal(req.file.location, 'mock-location')
+      assert.equal(req.file.serverSideEncryption, 'AES256')
+
+      done()
+    })
+  })
+
+  it('uploads file with AWS KMS-managed server-side encryption', function (done) {
+    var s3 = mockS3()
+    var form = new FormData()
+    var storage = multerS3({ s3: s3, bucket: 'test', sse: 'aws:kms' })
+    var upload = multer({ storage: storage })
+    var parser = upload.single('image')
+    var image = fs.createReadStream(path.join(__dirname, 'files', 'ffffff.png'))
+
+    form.append('name', 'Multer')
+    form.append('image', image)
+
+    submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+
+      assert.equal(req.body.name, 'Multer')
+
+      assert.equal(req.file.fieldname, 'image')
+      assert.equal(req.file.originalname, 'ffffff.png')
+      assert.equal(req.file.size, 68)
+      assert.equal(req.file.bucket, 'test')
+      assert.equal(req.file.etag, 'mock-etag')
+      assert.equal(req.file.location, 'mock-location')
+      assert.equal(req.file.serverSideEncryption, 'aws:kms')
+
+      done()
+    })
+  })
 })


### PR DESCRIPTION
This is my first PR and open source contribution, so please be gentle if I haven't met requirements for contribution. 

S3 has built-in server-side encryption that can be implemented via the API (docs [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html) and [here](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#upload-property)). This PR implements SSE using the S3-managed key system, as well as user-managed keys via [KMS](http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html). I have not implemented Customer-Provided Keys (SSE-C) in this PR, but may at some point in the future. 