### PR TITLE
Svg check for large files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var crypto = require('crypto')
 var stream = require('stream')
 var fileType = require('file-type')
-var isSvg = require('is-svg')
+var htmlCommentRegex = require('html-comment-regex')
 var parallel = require('run-parallel')
 
 function staticValue (value) {
@@ -20,6 +20,10 @@ var defaultStorageClass = staticValue('STANDARD')
 var defaultSSE = staticValue(null)
 var defaultSSEKMS = staticValue(null)
 
+// Regular expression to detect svg file content, inspired by: https://github.com/sindresorhus/is-svg/blob/master/index.js
+// It is not always possible to check for an end tag if a file is very big. The firstChunk, see below, might not be the entire file.
+var svgRegex = /^\s*(?:<\?xml[^>]*>\s*)?(?:<!doctype svg[^>]*\s*(?:\[?(?:\s*<![^>]*>\s*)*\]?)*[^>]*>\s*)?<svg[^>]*>/i
+
 function defaultKey (req, file, cb) {
   crypto.randomBytes(16, function (err, raw) {
     cb(err, err ? undefined : raw.toString('hex'))
@@ -29,14 +33,13 @@ function defaultKey (req, file, cb) {
 function autoContentType (req, file, cb) {
   file.stream.once('data', function (firstChunk) {
     var type = fileType(firstChunk)
-    var mime
+    var mime = 'application/octet-stream' // default type
 
-    if (type) {
-      mime = type.mime
-    } else if (isSvg(firstChunk)) {
+    // Make sure to check xml-extension for svg files.
+    if ((!type || type.ext === 'xml') && svgRegex.test(firstChunk.toString().replace(htmlCommentRegex, ''))) {
       mime = 'image/svg+xml'
-    } else {
-      mime = 'application/octet-stream'
+    } else if (type) {
+      mime = type.mime
     }
 
     var outStream = new stream.PassThrough()

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   },
   "homepage": "https://github.com/badunk/multer-s3#readme",
   "dependencies": {
-    "file-type": "^3.3.0",
-    "is-svg": "^2.1.0",
+    "file-type": "^8.1.0",
+    "html-comment-regex": "^1.1.1",
     "run-parallel": "^1.1.6"
   },
   "devDependencies": {

--- a/test/basic.js
+++ b/test/basic.js
@@ -173,7 +173,7 @@ describe('Multer S3', function () {
     })
   })
 
-  it('uploads SVG file with correct content-type', function (done) {
+  it('uploads pure SVG file with correct content-type', function (done) {
     var s3 = mockS3()
     var form = new FormData()
     var storage = multerS3({ s3: s3, bucket: 'test', serverSideEncryption: 'aws:kms', contentType: multerS3.AUTO_CONTENT_TYPE })
@@ -192,7 +192,36 @@ describe('Multer S3', function () {
       assert.equal(req.file.fieldname, 'image')
       assert.equal(req.file.contentType, 'image/svg+xml')
       assert.equal(req.file.originalname, 'test.svg')
-      assert.equal(req.file.size, 100)
+      assert.equal(req.file.size, 102)
+      assert.equal(req.file.bucket, 'test')
+      assert.equal(req.file.etag, 'mock-etag')
+      assert.equal(req.file.location, 'mock-location')
+      assert.equal(req.file.serverSideEncryption, 'aws:kms')
+
+      done()
+    })
+  })
+
+  it('uploads common SVG file with correct content-type', function (done) {
+    var s3 = mockS3()
+    var form = new FormData()
+    var storage = multerS3({ s3: s3, bucket: 'test', serverSideEncryption: 'aws:kms', contentType: multerS3.AUTO_CONTENT_TYPE })
+    var upload = multer({ storage: storage })
+    var parser = upload.single('image')
+    var image = fs.createReadStream(path.join(__dirname, 'files', 'test2.svg'))
+
+    form.append('name', 'Multer')
+    form.append('image', image)
+
+    submitForm(parser, form, function (err, req) {
+      assert.ifError(err)
+
+      assert.equal(req.body.name, 'Multer')
+
+      assert.equal(req.file.fieldname, 'image')
+      assert.equal(req.file.contentType, 'image/svg+xml')
+      assert.equal(req.file.originalname, 'test2.svg')
+      assert.equal(req.file.size, 292)
       assert.equal(req.file.bucket, 'test')
       assert.equal(req.file.etag, 'mock-etag')
       assert.equal(req.file.location, 'mock-location')

--- a/test/files/test2.svg
+++ b/test/files/test2.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<svg xmlns="http://www.w3.org/2000/svg"
+ width="226" height="226">
+  <circle cx="110" cy="107" r="80" stroke="black"
+      stroke-width="5" fill="red" />
+</svg>


### PR DESCRIPTION
* Big svg files will not have a complete first chunk to check for end tag in the svg, hence it is not possible to use isSvg.
* Updated file-type to latest version to get more correct file types.
* New test for the more common svg file type. That starts with an xml version and doctype.