### PR TITLE
Removed unnecessary dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,4 @@
 var crypto = require('crypto')
-var stream = require('stream')
-var fileType = require('file-type')
-var isSvg = require('is-svg')
 var parallel = require('run-parallel')
 
 function staticValue (value) {
@@ -27,25 +24,7 @@ function defaultKey (req, file, cb) {
 }
 
 function autoContentType (req, file, cb) {
-  file.stream.once('data', function (firstChunk) {
-    var type = fileType(firstChunk)
-    var mime
-
-    if (type) {
-      mime = type.mime
-    } else if (isSvg(firstChunk)) {
-      mime = 'image/svg+xml'
-    } else {
-      mime = 'application/octet-stream'
-    }
-
-    var outStream = new stream.PassThrough()
-
-    outStream.write(firstChunk)
-    file.stream.pipe(outStream)
-
-    cb(null, mime, outStream)
-  })
+  cb(null, file.mimetype, null)
 }
 
 function collect (storage, req, file, cb) {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
   },
   "homepage": "https://github.com/badunk/multer-s3#readme",
   "dependencies": {
-    "file-type": "^3.3.0",
-    "is-svg": "^2.1.0",
     "run-parallel": "^1.1.6"
   },
   "devDependencies": {


### PR DESCRIPTION
The is-svg package is not consistent at svg detection (mentioned on their readme). We do not really need an external library for this since the file object is already sent to the contentType callback along with it's mimetype. With this PR the npm package goes down from 12.6kb to 1.2kb.