### PR TITLE
Fix SVG bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,21 +27,32 @@ function defaultKey (req, file, cb) {
 }
 
 function autoContentType (req, file, cb) {
-  file.stream.once('data', function (firstChunk) {
-    var type = fileType(firstChunk)
+  var buffer = []
+
+  file.stream.on('data', function (chunk) {
+    buffer.push(chunk)
+  })
+
+  /**
+   *  While `fileType` only requires the first chunk of the file stream,
+   * `isSvg` requires the entire file to be read, so we must use the `end` event rather than `data`
+   */
+  file.stream.once('end', function () {
+    var data = Buffer.concat(buffer)
+    var type = fileType(data)
     var mime
 
-    if (type) {
-      mime = type.mime
-    } else if (isSvg(firstChunk)) {
+    if (isSvg(data)) {
       mime = 'image/svg+xml'
+    } else if (type) {
+      mime = type.mime
     } else {
       mime = 'application/octet-stream'
     }
 
     var outStream = new stream.PassThrough()
 
-    outStream.write(firstChunk)
+    outStream.write(data)
     file.stream.pipe(outStream)
 
     cb(null, mime, outStream)


### PR DESCRIPTION
The bug:

1. `fileType` will sometimes preemptively detect svg files as `application/xml` before `isSvg` is called.  We want it to be more specific.
2. `isSvg` requires inspecting the **entire** file contents, while `fileType` only requires the first chunk.

The solution:

1. `isSvg` is more specific, so move it above the `fileType` call.
2. Use the `end` event rather than `data` event for the file stream.