### PR TITLE
ContentLength parameter added (#179)

### DIFF
--- a/index.js
+++ b/index.js
@@ -195,6 +195,7 @@ S3Storage.prototype._handleFile = function (req, file, cb) {
       ACL: opts.acl,
       CacheControl: opts.cacheControl,
       ContentType: opts.contentType,
+      ContentLength: file.length,
       Metadata: opts.metadata,
       StorageClass: opts.storageClass,
       ServerSideEncryption: opts.serverSideEncryption,


### PR DESCRIPTION
Adds [content length](https://docs.aws.amazon.com/sdkfornet1/latest/apidocs/html/P_Amazon_Runtime_AmazonWebServiceResponse_ContentLength.htm) of file to S3 parameters.