### PR TITLE
Fix file size calculation

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ S3Storage.prototype._handleFile = function (req, file, cb) {
     })
 
     upload.on('httpUploadProgress', function (ev) {
-      if (ev.total) currentSize = ev.total
+      if (ev.total) currentSize = ev.total || ev.loaded
     })
 
     util.callbackify(upload.done.bind(upload))(function (err, result) {


### PR DESCRIPTION
AWS doesn't promise to always return the total loaded size, sometimes it just returns the data size that was request to be loaded.