### PR TITLE
Fixed file size calculation for some files

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ S3Storage.prototype._handleFile = function (req, file, cb) {
     })
 
     upload.on('httpUploadProgress', function (ev) {
-      if (ev.total) currentSize = ev.total
+      currentSize = ev.total || ev.loaded;
     })
 
     util.callbackify(upload.done.bind(upload))(function (err, result) {


### PR DESCRIPTION
In testing, I have had several files report a file size of 0, where others show the bytes as expected.

This PR is based on https://github.com/anacronw/multer-s3/pull/191.