### PR TITLE
Fix file size on larger multipart uploads

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,6 +217,7 @@ S3Storage.prototype._handleFile = function (req, file, cb) {
 
     upload.on('httpUploadProgress', function (ev) {
       if (ev.total) currentSize = ev.total
+      else if (ev.loaded) currentSize = ev.loaded
     })
 
     util.callbackify(upload.done.bind(upload))(function (err, result) {


### PR DESCRIPTION
We are encountering this problem with larger file uploads ,e.g. video files of roughly 20MB size. The `total` is missing, but the last event received has the actual file-size in the `loaded` property. This simple fix addresses this situation.

Fixes #183 